### PR TITLE
Add option to query multiple subelements

### DIFF
--- a/src/exml_query.erl
+++ b/src/exml_query.erl
@@ -9,6 +9,7 @@
 
 -export([path/2, path/3]).
 -export([subelement/2, subelement/3]).
+-export([subelements/2]).
 -export([attr/2, attr/3]).
 -export([cdata/1]).
 
@@ -26,6 +27,9 @@ path(#xmlelement{} = Element, [], _) ->
 path(#xmlelement{} = Element, [{element, Name} | Rest], Default) ->
     Child = subelement(Element, Name), % may return undefined
     path(Child, Rest, Default);
+path(#xmlelement{} = Element, [{elements, Name} | Rest], Default) ->
+    Children = subelements(Element, Name),
+    lists:concat([[path(Child, Rest, Default) || Child <- Children]]);
 path(#xmlelement{} = Element, [cdata], _) ->
     cdata(Element);
 path(#xmlelement{} = Element, [{attr, Name}], Default) ->
@@ -45,6 +49,15 @@ subelement(#xmlelement{body = Body}, Name, Default) ->
         Result ->
             Result
     end.
+
+-spec subelements(#xmlelement{}, binary()) -> [#xmlelement{}].
+subelements(#xmlelement{body = Body}, Name) ->
+    lists:filter(fun(#xmlelement{name = N}) when N =:= Name ->
+                        true;
+                    (_) ->
+                        false
+                 end,
+                 Body).
 
 -spec cdata(#xmlelement{}) -> binary().
 cdata(#xmlelement{body = Body}) ->

--- a/test/exml_query_tests.erl
+++ b/test/exml_query_tests.erl
@@ -29,9 +29,20 @@ element_query_test() ->
     ?assertEqual(xml(<<"<problem no='1'>is too big</problem>">>),
                  exml_query:path(?MY_SPOON, [{element, <<"problem">>}])).
 
+elements_query_test() ->
+    Exemplar = [xml(<<"<problem no='1'>is too big</problem>">>),
+                xml(<<"<problem no='2'>is too big</problem>">>),
+                xml(<<"<problem no='3'>is too big</problem>">>)],
+    ?assertEqual(Exemplar, exml_query:subelements(?MY_SPOON, <<"problem">>)),
+    ?assertEqual(Exemplar, exml_query:path(?MY_SPOON,
+                                           [{elements, <<"problem">>}])).
+
 attribute_query_test() ->
     ?assertEqual(<<"my">>, exml_query:attr(?MY_SPOON, <<"whose">>)),
     ?assertEqual(<<"my">>, exml_query:path(?MY_SPOON, [{attr, <<"whose">>}])),
+    ?assertEqual([<<"1">>, <<"2">>, <<"3">>],
+                 exml_query:path(?MY_SPOON, [{elements, <<"problem">>},
+                                             {attr, <<"no">>}])),
     ?assertEqual(undefined, exml_query:attr(?MY_SPOON, <<"banana">>)),
     ?assertEqual('IAmA', exml_query:attr(?MY_SPOON, <<"banana">>, 'IAmA')).
 


### PR DESCRIPTION
...not only the "leftmost" one.

It's convenient e.g. for getting all 'feature' subelements from a response to iq query.
