### PR TITLE
add attribute parsing for #xmlstreamstart

### DIFF
--- a/src/exml_query.erl
+++ b/src/exml_query.erl
@@ -5,7 +5,7 @@
 %%%-------------------------------------------------------------------
 -module(exml_query).
 
--include("exml.hrl").
+-include("exml_stream.hrl").
 
 -export([path/2, path/3]).
 -export([paths/2]).
@@ -17,12 +17,12 @@
 -type path() :: [cdata | {element, binary()} | {attr, binary()}].
 
 %% @doc gets the element/attr/cdata contained in the leftmost path
--spec path(#xmlelement{}, path()) -> #xmlelement{} | binary() | undefined.
+-spec path(#xmlelement{} | #xmlstreamstart{}, path()) -> #xmlelement{} | binary() | undefined.
 path(Element, Path) ->
     path(Element, Path, undefined).
 
 %% @doc gets the element/attr/cdata in the leftmost possible described path
--spec path(#xmlelement{}, path(), Other) -> #xmlelement{} | binary() | Other.
+-spec path(#xmlelement{} | #xmlstreamstart{}, path(), Other) -> #xmlelement{} | binary() | Other.
 path(#xmlelement{} = Element, [], _) ->
     Element;
 path(#xmlelement{} = Element, [{element, Name} | Rest], Default) ->
@@ -31,6 +31,8 @@ path(#xmlelement{} = Element, [{element, Name} | Rest], Default) ->
 path(#xmlelement{} = Element, [cdata], _) ->
     cdata(Element);
 path(#xmlelement{} = Element, [{attr, Name}], Default) ->
+    attr(Element, Name, Default);
+path(#xmlstreamstart{} = Element, [{attr, Name}], Default) ->
     attr(Element, Name, Default);
 path(_, _, Default) ->
     Default.
@@ -74,12 +76,16 @@ subelements(#xmlelement{children = Children}, Name) ->
 cdata(#xmlelement{children = Children}) ->
     list_to_binary([exml:unescape_cdata(C) || #xmlcdata{} = C <- Children]).
 
--spec attr(#xmlelement{}, binary()) -> binary() | undefined.
+-spec attr(#xmlelement{} | #xmlstreamstart{}, binary()) -> binary() | undefined.
 attr(Element, Name) ->
     attr(Element, Name, undefined).
 
--spec attr(#xmlelement{}, binary(), Other) -> binary() | Other.
+-spec attr(#xmlelement{} | #xmlstreamstart{} | list(), binary(), Other) -> binary() | Other.
 attr(#xmlelement{attrs = Attrs}, Name, Default) ->
+    attr(Attrs, Name, Default);
+attr(#xmlstreamstart{attrs = Attrs}, Name, Default) ->
+    attr(Attrs, Name, Default);
+attr(Attrs, Name, Default) ->
     case lists:keyfind(Name, 1, Attrs) of
         {Name, Value} ->
             Value;

--- a/test/exml_query_tests.erl
+++ b/test/exml_query_tests.erl
@@ -8,7 +8,7 @@
 -module(exml_query_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include("exml.hrl").
+-include("exml_stream.hrl").
 
 -compile(export_all).
 
@@ -45,11 +45,18 @@ elements_query_test() ->
                 xml(<<"<problem no='3'>is too big</problem>">>)],
     ?assertEqual(Exemplar, exml_query:subelements(?MY_SPOON, <<"problem">>)).
 
-attribute_query_test() ->
+xmlelement_attribute_query_test() ->
     ?assertEqual(<<"my">>, exml_query:attr(?MY_SPOON, <<"whose">>)),
     ?assertEqual(<<"my">>, exml_query:path(?MY_SPOON, [{attr, <<"whose">>}])),
     ?assertEqual(undefined, exml_query:attr(?MY_SPOON, <<"banana">>)),
     ?assertEqual('IAmA', exml_query:attr(?MY_SPOON, <<"banana">>, 'IAmA')).
+
+xmlstreamstart_attribute_query_test() ->
+    XmlStreamStart = #xmlstreamstart{name = <<"stream:stream">>, attrs = [{<<"whose">>, <<"my">>}]},
+    ?assertEqual(<<"my">>, exml_query:attr(XmlStreamStart, <<"whose">>)),
+    ?assertEqual(<<"my">>, exml_query:path(XmlStreamStart, [{attr, <<"whose">>}])),
+    ?assertEqual(undefined, exml_query:attr(XmlStreamStart, <<"banana">>)),
+    ?assertEqual('IAmA', exml_query:attr(XmlStreamStart, <<"banana">>, 'IAmA')).
 
 cdata_query_test() ->
     ?assertEqual(<<"">>, exml_query:cdata(?MY_SPOON)),


### PR DESCRIPTION
Currently, `exml_query:attr/2,3` and `exml_query:path/2,3` return an error if the element is a `#xmlstreamstart{}`.

This pull request allows to get elements on a stream, for instance:

``` erlang

1> rr(exml).
[xmlcdata,xmlelement,xmlstreamend,xmlstreamstart]
2> El = #xmlstreamstart{name = <<"stream:stream">>, attrs = [{<<"who">>, <<"me">>}]}.
#xmlstreamstart{name = <<"stream:stream">>,
                attrs = [{<<"who">>,<<"me">>}]}
3> exml_query:attr(El, <<"who">>).
<<"me">>
```
