### PR TITLE
Cleaned up and fixed incorrect function specs

### DIFF
--- a/src/exml_event.erl
+++ b/src/exml_event.erl
@@ -40,7 +40,7 @@ parse_final(Parser, Data) ->
     do_parse(Parser, Data, ?FINAL, byte_size(Data), []).
 
 -spec do_parse(term(), binary(), 0 | 1, integer(), list()) ->
-                      {ok, list()} | {error, string()}.
+    {ok, list()} | {error, string()}.
 do_parse(Parser, Data, Final, Size, Acc) when Size > ?MAX_BYTES_TO_NIF ->
     <<DataToPass:?MAX_BYTES_TO_NIF/binary, Rest/binary>> = Data,
     case parse_nif(Parser, DataToPass, ?NOT_FINAL) of
@@ -58,7 +58,7 @@ do_parse(Parser, Data, Final, _Size, Acc) ->
             Error
     end.
 
--spec new_parser() -> term().
+-spec new_parser() -> {ok, term()}.
 new_parser() ->
     erlang:nif_error({?MODULE, nif_not_loaded}).
 
@@ -70,7 +70,7 @@ reset_parser(_Parser) ->
 free_parser(_Parser) ->
     erlang:nif_error({?MODULE, nif_not_loaded}).
 
--spec parse_nif(term(), binary(), integer()) -> list().
+-spec parse_nif(term(), binary(), integer()) -> {ok, list()} | {error, string()}.
 parse_nif(_Parser, _Data, _Final) ->
     erlang:nif_error({?MODULE, nif_not_loaded}).
 

--- a/src/exml_stream.erl
+++ b/src/exml_stream.erl
@@ -27,7 +27,7 @@
 %%% Public API
 %%%===================================================================
 
--spec new_parser() -> {ok, #parser{}} | {error, any()}.
+-spec new_parser() -> {ok, parser()} | {error, any()}.
 new_parser() ->
     case exml_event:new_parser() of
         {ok, EventParser} ->
@@ -36,8 +36,8 @@ new_parser() ->
             {error, Error}
     end.
 
--spec parse(#parser{}, binary()) ->
-        {ok, #parser{}, [xmlstreamelement()]} | {error, {string(), binary()}}.
+-spec parse(parser(), binary()) ->
+    {ok, parser(), [xmlstreamelement()]} | {error, {string(), binary()}}.
 parse(#parser{event_parser = EventParser, stack = OldStack} = Parser, Input) ->
     case exml_event:parse(EventParser, Input) of
         {ok, Events} ->
@@ -47,7 +47,7 @@ parse(#parser{event_parser = EventParser, stack = OldStack} = Parser, Input) ->
             {error, {Msg, Input}}
     end.
 
--spec reset_parser(#parser{}) -> {ok, #parser{}} | {error, any()}.
+-spec reset_parser(parser()) -> {ok, parser()} | {error, any()}.
 reset_parser(#parser{event_parser=EventParser}) ->
     case exml_event:reset_parser(EventParser) of
         ok ->
@@ -57,7 +57,7 @@ reset_parser(#parser{event_parser=EventParser}) ->
             {error, Error}
     end.
 
--spec free_parser(#parser{}) -> ok | {error, any()}.
+-spec free_parser(parser()) -> ok | {error, any()}.
 free_parser(#parser{event_parser = EventParser}) ->
     exml_event:free_parser(EventParser).
 


### PR DESCRIPTION
There were a few incorrect functions specs. Also I replaced #parser{} with custom parser() type in specs.
